### PR TITLE
nvm_bbt: free "spec" before return.

### DIFF
--- a/src/nvm_bbt.c
+++ b/src/nvm_bbt.c
@@ -222,6 +222,7 @@ const struct nvm_bbt *nvm_bbt_get(struct nvm_dev *dev, struct nvm_addr addr,
 
 	if (dev->bbts[bbt_idx]->nblks != spec->tblks) {
 		free(dev->bbts[bbt_idx]);
+        free(spec);
 		dev->bbts[bbt_idx] = NULL;
 
 		return NULL;


### PR DESCRIPTION
Looks like "spec" need be freed, otherwise may cause memory leak. 

Regards,
George

