### PR TITLE
Spec2.1811

### DIFF
--- a/cli/cli_cmd.c
+++ b/cli/cli_cmd.c
@@ -65,7 +65,7 @@ static int cmd_idfy(struct nvm_cli *cli)
 	if (!idfy)
 		return -1;
 
-	nvm_spec_idfy_pr(idfy, nvm_dev_get_quirks(dev));
+	nvm_spec_idfy_pr(idfy);
 
 	nvm_buf_free(idfy);
 

--- a/include/liblightnvm.h
+++ b/include/liblightnvm.h
@@ -80,7 +80,6 @@ enum nvm_quirks {
 	NVM_QUIRK_NSID_BY_NAMECONV		= 0x1 << 1,
 	NVM_QUIRK_OOB_READ_1ST4BYTES_NULL	= 0x1 << 2,
 	NVM_QUIRK_OOB_2LRG			= 0x1 << 3,
-	NVM_QUIRK_SEMI20			= 0x1 << 4
 };
 
 /**

--- a/include/liblightnvm_spec.h
+++ b/include/liblightnvm_spec.h
@@ -248,22 +248,6 @@ struct nvm_spec_perf {
 	uint8_t		resv[40];
 };
 
-/*
-struct nvm_spec_idfy_s13 {
-	uint8_t				verid;
-	uint8_t				verid_minor;
-	uint8_t				rsvd1[2];
-	struct nvm_spec_lbaf		lbaf;
-	struct nvm_spec_ppaf_nand	ppaf;
-	uint8_t				rsvd2[4];
-	uint32_t			mccap;
-	uint8_t				rsvd3[28];
-	struct nvm_spec_lgeo		lgeo;
-	struct nvm_spec_wrt		wrt;
-	struct nvm_spec_perf		perf;
-	uint8_t				rsvd4;
-}; arav */
-
 struct nvm_spec_idfy_s20 {
 	uint8_t				verid;
 	uint8_t				verid_minor;
@@ -287,7 +271,6 @@ static_assert(sizeof(struct nvm_spec_idfy_s20) == 4096, "Incorrect size");
 struct nvm_spec_idfy {
 	union {
 		struct nvm_spec_idfy_s12 s12;
-		//struct nvm_spec_idfy_s13 s13; arav
 		struct nvm_spec_idfy_s20 s20;
 
 		struct {

--- a/include/liblightnvm_spec.h
+++ b/include/liblightnvm_spec.h
@@ -248,6 +248,7 @@ struct nvm_spec_perf {
 	uint8_t		resv[40];
 };
 
+/*
 struct nvm_spec_idfy_s13 {
 	uint8_t				verid;
 	uint8_t				verid_minor;
@@ -261,7 +262,7 @@ struct nvm_spec_idfy_s13 {
 	struct nvm_spec_wrt		wrt;
 	struct nvm_spec_perf		perf;
 	uint8_t				rsvd4;
-};
+}; arav */
 
 struct nvm_spec_idfy_s20 {
 	uint8_t				verid;
@@ -286,7 +287,7 @@ static_assert(sizeof(struct nvm_spec_idfy_s20) == 4096, "Incorrect size");
 struct nvm_spec_idfy {
 	union {
 		struct nvm_spec_idfy_s12 s12;
-		struct nvm_spec_idfy_s13 s13;
+		//struct nvm_spec_idfy_s13 s13; arav
 		struct nvm_spec_idfy_s20 s20;
 
 		struct {
@@ -298,7 +299,7 @@ struct nvm_spec_idfy {
 };
 static_assert(sizeof(struct nvm_spec_idfy) == 4096, "Incorrect size");
 
-void nvm_spec_idfy_pr(const struct nvm_spec_idfy *idfy, int quirks);
+void nvm_spec_idfy_pr(const struct nvm_spec_idfy *idfy);
 
 struct nvm_spec_bbt {
 	uint8_t		tblid[4];

--- a/src/nvm_spec.c
+++ b/src/nvm_spec.c
@@ -219,21 +219,6 @@ static void nvm_spec_idfy_s12_pr(const struct nvm_spec_idfy *identify)
 	}
 }
 
-static void nvm_spec_idfy_s13_pr(const struct nvm_spec_idfy *identify)
-{
-	struct nvm_spec_idfy_s13 idfy = identify->s13;
-
-	printf("idfy:\n");
-	printf("  verid: "NVM_I8_FMT"\n", NVM_I8_TO_STR(idfy.verid));
-	printf("  verid_minor: "NVM_I8_FMT"\n", NVM_I8_TO_STR(idfy.verid_minor));
-	printf("  mccap: "NVM_I32_FMT"\n", NVM_I32_TO_STR(idfy.mccap));
-	nvm_spec_ppaf_nand_pr(&idfy.ppaf);
-	nvm_spec_lbaf_pr(&idfy.lbaf);
-	nvm_spec_lgeo_pr(&idfy.lgeo);
-	nvm_spec_wrt_pr(&idfy.wrt);
-	nvm_spec_perf_pr(&idfy.perf);
-}
-
 static void nvm_spec_idfy_s20_pr(const struct nvm_spec_idfy *identify)
 {
 	struct nvm_spec_idfy_s20 idfy = identify->s20;
@@ -248,32 +233,27 @@ static void nvm_spec_idfy_s20_pr(const struct nvm_spec_idfy *identify)
 	nvm_spec_perf_pr(&idfy.perf);
 }
 
-void nvm_spec_idfy_pr(const struct nvm_spec_idfy *idfy, int quirks)
+void nvm_spec_idfy_pr(const struct nvm_spec_idfy *idfy)
 {
 	if (!idfy) {
 		printf("nvm_spec_idfy: ~\n");
 		return;
 	}
+	switch(idfy->s.verid) {
+	case NVM_SPEC_VERID_12:
+		nvm_spec_idfy_s12_pr(idfy);
+		break;
 
-	if (quirks & NVM_QUIRK_SEMI20) {
-		nvm_spec_idfy_s13_pr(idfy);
-	} else {
-		switch(idfy->s.verid) {
-		case NVM_SPEC_VERID_12:
-			nvm_spec_idfy_s12_pr(idfy);
-			break;
+	case NVM_SPEC_VERID_20:
+		nvm_spec_idfy_s20_pr(idfy);
+		break;
 
-		case NVM_SPEC_VERID_20:
-			nvm_spec_idfy_s20_pr(idfy);
-			break;
-
-		default:
-			printf("nvm_spec_idfy:\n");
-			printf("  verid: "NVM_I8_FMT",\n",
-			       NVM_I8_TO_STR(idfy->s.verid));
-			printf("  verid_minor: "NVM_I8_FMT",\n",
-			       NVM_I8_TO_STR(idfy->s.verid_minor));
-		}
+	default:
+		printf("nvm_spec_idfy:\n");
+		printf("  verid: "NVM_I8_FMT",\n",
+		       NVM_I8_TO_STR(idfy->s.verid));
+		printf("  verid_minor: "NVM_I8_FMT",\n",
+		       NVM_I8_TO_STR(idfy->s.verid_minor));
 	}
 }
 


### PR DESCRIPTION
Changes to remove code which was handling spec 1.3.

nvm_dev info /dev/nvme0n1 was reporting version as 1 even though the version was 2.
Also "nvm_addr s20_to_gen "would not give a proper address if sectors went beyond 4(fail with sector exceeded error).
This was due to handling a "idfy" case in nvm_be_populate() function where version is set to 1 forcibly. Instead of fixing that one specific case, Matias suggested to remove all 1.3 spec related to code, hence this pull request.
Open for any suggestions/modifications.
Done basic testing and verified that version was reported correctly (as 2 ) and nvm_addr was able to generate addresses properly for larger sector numbers(4095), and other commands were working as expected.
