### PR TITLE
Added terse support for nvm_addr command.

### DIFF
--- a/cli/cli_addr.c
+++ b/cli/cli_addr.c
@@ -132,7 +132,8 @@ static int cmd_fmt(struct nvm_cli *cli)
 {
 	struct nvm_cli_cmd_args *args = &cli->args;
 
-	nvm_addr_prn(args->addrs, args->naddrs, args->dev);
+	cli->opts.terse ? nvm_addr_pr((args->addrs[0])) :
+                        nvm_addr_prn(args->addrs, args->naddrs, args->dev);
 
 	return 0;
 }
@@ -140,6 +141,13 @@ static int cmd_fmt(struct nvm_cli *cli)
 static int cmd_gen2dev(struct nvm_cli *cli)
 {
 	struct nvm_cli_cmd_args *args = &cli->args;
+
+	if (cli->opts.terse) {
+		for (int i = 0; i < args->naddrs; ++i) {
+			printf("0x%016"PRIx64"\n", nvm_addr_gen2dev(args->dev, args->addrs[i]));
+		}
+		return 0;
+	}
 
 	for (int i = 0; i < args->naddrs; ++i) {
 		printf("gen: ");
@@ -154,6 +162,13 @@ static int cmd_gen2lba(struct nvm_cli *cli)
 {
 	struct nvm_cli_cmd_args *args = &cli->args;
 
+	if (cli->opts.terse) {
+		for (int i = 0; i < args->naddrs; ++i) {
+			printf("%064"PRIu64"\n", nvm_addr_gen2lba(args->dev, args->addrs[i]));
+		}
+		return 0;
+	}
+
 	for (int i = 0; i < args->naddrs; ++i) {
 		printf("gen: "); nvm_addr_pr(args->addrs[i]);
 		printf("lba: %064"PRIu64"\n", nvm_addr_gen2lba(args->dev, args->addrs[i]));
@@ -165,6 +180,13 @@ static int cmd_gen2lba(struct nvm_cli *cli)
 static int cmd_gen2off(struct nvm_cli *cli)
 {
 	struct nvm_cli_cmd_args *args = &cli->args;
+
+	if (cli->opts.terse) {
+		for (int i = 0; i < args->naddrs; ++i) {
+			printf("%064"PRIu64"\n", nvm_addr_gen2off(args->dev, args->addrs[i]));
+		}
+		return 0;
+	}
 
 	for (int i = 0; i < args->naddrs; ++i) {
 		printf("gen: "); nvm_addr_pr(args->addrs[i]);
@@ -178,6 +200,13 @@ static int cmd_gen2lpo(struct nvm_cli *cli)
 {
 	struct nvm_cli_cmd_args *args = &cli->args;
 
+	if (cli->opts.terse) {
+		for (int i = 0; i < args->naddrs; ++i) {
+			printf("%064"PRIu64"\n", nvm_addr_gen2lpo(args->dev, args->addrs[i]));
+		}
+		return 0;
+	}
+
 	for (int i = 0; i < args->naddrs; ++i) {
 		printf("gen: "); nvm_addr_pr(args->addrs[i]);
 		printf("lpo: %064"PRIu64"\n", nvm_addr_gen2lpo(args->dev, args->addrs[i]));
@@ -189,6 +218,15 @@ static int cmd_gen2lpo(struct nvm_cli *cli)
 static int cmd_dev2gen(struct nvm_cli *cli)
 {
 	struct nvm_cli_cmd_args *args = &cli->args;
+
+	if (cli->opts.terse) {
+		for (int i = 0; i < args->nhex_vals; ++i) {
+			struct nvm_addr gen = { 0 };
+			gen = nvm_addr_dev2gen(args->dev, args->hex_vals[i]);
+			nvm_addr_pr(gen);
+		}
+		return 0;
+	}
 
 	for (int i = 0; i < args->nhex_vals; ++i) {
 		struct nvm_addr gen = { 0 };
@@ -207,6 +245,15 @@ static int cmd_lba2gen(struct nvm_cli *cli)
 {
 	struct nvm_cli_cmd_args *args = &cli->args;
 
+	if (cli->opts.terse) {
+		for (int i = 0; i < args->ndec_vals; ++i) {
+			struct nvm_addr gen = { 0 };
+			gen = nvm_addr_lba2gen(args->dev, args->dec_vals[i]);
+			nvm_addr_pr(gen);
+		}
+		return 0;
+	}
+
 	for (int i = 0; i < args->ndec_vals; ++i) {
 		struct nvm_addr gen = { 0 };
 
@@ -224,6 +271,15 @@ static int cmd_off2gen(struct nvm_cli *cli)
 {
 	struct nvm_cli_cmd_args *args = &cli->args;
 
+	if (cli->opts.terse) {
+		for (int i = 0; i < args->ndec_vals; ++i) {
+			struct nvm_addr gen = { 0 };
+			gen = nvm_addr_off2gen(args->dev, args->dec_vals[i]);
+			nvm_addr_pr(gen);
+		}
+		return 0;
+	}
+
 	for (int i = 0; i < args->ndec_vals; ++i) {
 		struct nvm_addr gen = { 0 };
 
@@ -240,6 +296,16 @@ static int cmd_off2gen(struct nvm_cli *cli)
 static int cmd_lpo2gen(struct nvm_cli *cli)
 {
 	struct nvm_cli_cmd_args *args = &cli->args;
+
+	if (cli->opts.terse) {
+		for (int i = 0; i < args->ndec_vals; ++i) {
+			struct nvm_addr gen = { 0 };
+			gen = nvm_addr_lpo2gen(args->dev, args->dec_vals[i]);
+			//nvm_addr_terse_prn(&gen, 1, args->dev);
+			nvm_addr_pr(gen);
+		}
+		return 0;
+	}
 
 	for (int i = 0; i < args->ndec_vals; ++i) {
 		struct nvm_addr gen = { 0 };
@@ -263,20 +329,20 @@ static int cmd_lpo2gen(struct nvm_cli *cli)
 /* Define commands */
 static struct nvm_cli_cmd cmds[] = {
 
-	{"s12_to_gen",	cmd_fmt,	NVM_CLI_ARG_ADDR_S12, NVM_CLI_OPT_DEFAULT},
-	{"s20_to_gen",	cmd_fmt,	NVM_CLI_ARG_ADDR_S20, NVM_CLI_OPT_DEFAULT},
+	{"s12_to_gen",	cmd_fmt,	NVM_CLI_ARG_ADDR_S12, NVM_CLI_OPT_DEFAULT|NVM_CLI_OPT_TERSE},
+	{"s20_to_gen",	cmd_fmt,	NVM_CLI_ARG_ADDR_S20, NVM_CLI_OPT_DEFAULT|NVM_CLI_OPT_TERSE},
 
 	//{"from_hex",		cmd_fmt,	NVM_CLI_ARG_ADDR_LIST, NVM_CLI_OPT_DEFAULT},
 	
-	{"gen2dev",	cmd_gen2dev,	NVM_CLI_ARG_ADDR_LIST, NVM_CLI_OPT_DEFAULT},
-	{"gen2lba",	cmd_gen2lba,	NVM_CLI_ARG_ADDR_LIST, NVM_CLI_OPT_DEFAULT},
-	{"gen2off",	cmd_gen2off,	NVM_CLI_ARG_ADDR_LIST, NVM_CLI_OPT_DEFAULT},
-	{"gen2lpo",	cmd_gen2lpo,	NVM_CLI_ARG_ADDR_LIST, NVM_CLI_OPT_DEFAULT},
+	{"gen2dev",	cmd_gen2dev,	NVM_CLI_ARG_ADDR_LIST, NVM_CLI_OPT_DEFAULT|NVM_CLI_OPT_TERSE},
+	{"gen2lba",	cmd_gen2lba,	NVM_CLI_ARG_ADDR_LIST, NVM_CLI_OPT_DEFAULT|NVM_CLI_OPT_TERSE},
+	{"gen2off",	cmd_gen2off,	NVM_CLI_ARG_ADDR_LIST, NVM_CLI_OPT_DEFAULT|NVM_CLI_OPT_TERSE},
+	{"gen2lpo",	cmd_gen2lpo,	NVM_CLI_ARG_ADDR_LIST, NVM_CLI_OPT_DEFAULT|NVM_CLI_OPT_TERSE},
 
-	{"dev2gen",	cmd_dev2gen,	NVM_CLI_ARG_HEXVAL_LIST, NVM_CLI_OPT_DEFAULT},
-	{"lba2gen",	cmd_lba2gen,	NVM_CLI_ARG_DECVAL_LIST, NVM_CLI_OPT_DEFAULT},
-	{"off2gen",	cmd_off2gen,	NVM_CLI_ARG_DECVAL_LIST, NVM_CLI_OPT_DEFAULT},
-	{"lpo2gen",	cmd_lpo2gen,	NVM_CLI_ARG_DECVAL_LIST, NVM_CLI_OPT_DEFAULT},
+	{"dev2gen",	cmd_dev2gen,	NVM_CLI_ARG_HEXVAL_LIST, NVM_CLI_OPT_DEFAULT|NVM_CLI_OPT_TERSE},
+	{"lba2gen",	cmd_lba2gen,	NVM_CLI_ARG_DECVAL_LIST, NVM_CLI_OPT_DEFAULT|NVM_CLI_OPT_TERSE},
+	{"off2gen",	cmd_off2gen,	NVM_CLI_ARG_DECVAL_LIST, NVM_CLI_OPT_DEFAULT|NVM_CLI_OPT_TERSE},
+	{"lpo2gen",	cmd_lpo2gen,	NVM_CLI_ARG_DECVAL_LIST, NVM_CLI_OPT_DEFAULT|NVM_CLI_OPT_TERSE},
 };
 
 /* Define the CLI */

--- a/cli/cli_addr.c
+++ b/cli/cli_addr.c
@@ -210,7 +210,7 @@ static int cmd_lba2gen(struct nvm_cli *cli)
 	for (int i = 0; i < args->ndec_vals; ++i) {
 		struct nvm_addr gen = { 0 };
 
-		gen = nvm_addr_lba2gen(args->dev, args->hex_vals[i]);
+		gen = nvm_addr_lba2gen(args->dev, args->dec_vals[i]);
 
 		printf("lba: %064"PRIu64"\n", args->dec_vals[i]);
 		printf("gen: ");

--- a/doc/src/cli/nvm_addr.rst
+++ b/doc/src/cli/nvm_addr.rst
@@ -38,3 +38,20 @@ in generic format:
 
 .. literalinclude:: nvm_addr_gen2dev.out
    :language: bash
+
+Terse Format
+~~~~~~~~~~~~
+
+Prints the just the address:
+
+.. literalinclude:: nvm_addr_tex01.cmd
+   :language: bash
+
+.. literalinclude:: nvm_addr_tex01.out
+   :language: bash
+
+.. literalinclude:: nvm_addr_tex02.cmd
+   :language: bash
+
+.. literalinclude:: nvm_addr_tex02.out
+   :language: bash

--- a/doc/src/cli/nvm_addr_tex01.cmd
+++ b/doc/src/cli/nvm_addr_tex01.cmd
@@ -1,0 +1,1 @@
+nvm_addr s20_to_gen /dev/nvme0n1 0 3 42 134 -t

--- a/doc/src/cli/nvm_addr_tex02.cmd
+++ b/doc/src/cli/nvm_addr_tex02.cmd
@@ -1,0 +1,1 @@
+nvm_vblk erase /dev/nvme0n1 $(sudo nvm_addr s20_to_gen /dev/nvme0n1 0 0 3 4 -t)

--- a/include/liblightnvm.h
+++ b/include/liblightnvm.h
@@ -1111,6 +1111,7 @@ void nvm_addr_pr(const struct nvm_addr addr);
 void nvm_addr_prn(const struct nvm_addr *addr, unsigned int naddrs,
 		  const struct nvm_dev *dev);
 
+
 /**
  * Allocate a virtual block, spanning a given set of physical blocks
  *

--- a/include/liblightnvm_cli.h
+++ b/include/liblightnvm_cli.h
@@ -128,6 +128,7 @@ enum nvm_cli_opt_type {
 	NVM_CLI_OPT_FILE_OUTPUT = 1 << 5,
 	NVM_CLI_OPT_VAL_DEC = 1 << 6,
 	NVM_CLI_OPT_VAL_HEX = 1 << 7,
+	NVM_CLI_OPT_TERSE = 1 << 8,
 };
 
 #define NVM_CLI_OPT_DEFAULT (NVM_CLI_OPT_HELP | NVM_CLI_OPT_VERBOSE)
@@ -140,6 +141,7 @@ struct nvm_cli_opts {
 	int help;		///< For NVM_CLI_OPT_HELP
 	int brief;		///< For NVM_CLI_OPT_BRIEF
 	int verbose;		///< For NVM_CLI_OPT_VERBOSE
+	int terse;
 	int status;		///< FOR NVM_CLI_OPT_STATUS
 	char *file_input;	///< For NVM_CLI_OPT_FILE_INPUT
 	char *file_output;	///< For NVM_CLI_OPT_FILE_OUTPUT

--- a/src/nvm_addr.c
+++ b/src/nvm_addr.c
@@ -44,7 +44,7 @@ void nvm_ret_pr(const struct nvm_ret *ret)
 
 void nvm_addr_pr(const struct nvm_addr addr)
 {
-	printf("0x%016"PRIx64", ", addr.val);
+	printf("0x%016"PRIx64"\n", addr.val);
 }
 
 static void nvm_addr_pr_s12(struct nvm_addr addr)

--- a/src/nvm_cli.c
+++ b/src/nvm_cli.c
@@ -100,7 +100,7 @@ void nvm_cli_timer_bw_pr(const char *prefix, size_t nbytes)
 
 int _parse_options(int argc, char *argv[], struct nvm_cli *cli)
 {
-	for (int opt = 0; (opt = getopt(argc, argv, ":hbvi:o:n:x:")) != -1;) {
+	for (int opt = 0; (opt = getopt(argc, argv, ":hbvti:o:n:x:")) != -1;) {
 		switch(opt) {
 		case 'h':
 			cli->opts.mask |= NVM_CLI_OPT_HELP;
@@ -117,6 +117,10 @@ int _parse_options(int argc, char *argv[], struct nvm_cli *cli)
 		case 's':
 			cli->opts.mask |= NVM_CLI_OPT_STATUS;
 			cli->opts.status = 1;
+			break;
+		case 't':
+			cli->opts.mask |= NVM_CLI_OPT_TERSE;
+			cli->opts.terse = 1;
 			break;
 		case 'i':
 			cli->opts.mask |= NVM_CLI_OPT_FILE_INPUT;
@@ -1189,6 +1193,9 @@ void _nvm_cli_opts_mask_pr(int mask) {
 		case NVM_CLI_OPT_STATUS:
 			printf(" [-s]");
 			break;
+		case NVM_CLI_OPT_TERSE:
+			printf(" [-t]");
+			break;
 		case NVM_CLI_OPT_FILE_INPUT:
 			printf(" [-i FILE]");
 			break;
@@ -1227,6 +1234,9 @@ void _nvm_cli_opts_mask_descr_pr(int mask) {
 			break;
 		case NVM_CLI_OPT_STATUS:
 			printf(" -s %5s %s", " ", "Dump status msgs to stdout");
+			break;
+		case NVM_CLI_OPT_TERSE:
+			printf(" -t %5s %s", " ", "Print only the address");
 			break;
 		case NVM_CLI_OPT_FILE_INPUT:
 			printf(" -i %5s %s", "FILE", "Path to input file");
@@ -1417,6 +1427,7 @@ void nvm_cli_opts_pr(struct nvm_cli_opts *opts)
 	printf("  help: %d\n", opts->help);
 	printf("  brief: %d\n", opts->brief);
 	printf("  verbose: %d\n", opts->verbose);
+	printf("  terse: %d\n", opts->terse);
 	printf("  dec_val: %zu\n", opts->dec_val);
 	printf("  hex_val: 0x%016"PRIx64"\n", opts->hex_val);
 	printf("  file_input: %s\n", opts->file_input);

--- a/src/nvm_spec.c
+++ b/src/nvm_spec.c
@@ -302,11 +302,11 @@ void nvm_spec_rprt_pr(const struct nvm_spec_rprt *rprt)
 
 		printf("  - { ");
 		printf("slba: 0x%016lX, ", descr->addr);
-		printf("cnlb: %04lu, ", descr->naddrs);
-		printf("wp: %016lu, ", descr->wp);
+		printf("cnlb: 0x%04lx, ", descr->naddrs);
+		printf("wp: 0x%016lx, ", descr->wp);
 		printf("cs: 0x%02X, ", descr->cs);
 		printf("ct: 0x%02X, ", descr->ct);
-		printf("wli: %03u", descr->wli);
+		printf("wli: 0x%02x", descr->wli);
 		printf(" }\n");
 	}
 }


### PR DESCRIPTION
Hi Simon,
I have created a pull request with the change for adding support to terse option for nvm_addr cmd, "-t" is added to nvm_addr command. I have created the pull request to the pprint branch, but I am ok if it goes to master as well.
Kindly review.

I have attached the file with the manual UT that i ran.

Thanks,
[terse-ut.txt](https://github.com/OpenChannelSSD/liblightnvm/files/2163228/terse-ut.txt)

Aravind

############Test results########
aravind@ocssd:~/OCSSD$ sudo build/cli/nvm_addr
NVM address (nvm_addr_*) -- Ver { major(0), minor(1), patch(2) }

Construct and convert addresses

Usage:
 build/cli/nvm_addr   s12_to_gen dev_path ch lun blk pl pg sec [-h] [-v] [-t]
 build/cli/nvm_addr   s20_to_gen dev_path pugrp punit chunk sectr [-h] [-v] [-t]
 build/cli/nvm_addr      gen2dev dev_path 0xADDR [0xADDR...] [-h] [-v] [-t]
 build/cli/nvm_addr      gen2lba dev_path 0xADDR [0xADDR...] [-h] [-v] [-t]
 build/cli/nvm_addr      gen2off dev_path 0xADDR [0xADDR...] [-h] [-v] [-t]
 build/cli/nvm_addr      gen2lpo dev_path 0xADDR [0xADDR...] [-h] [-v] [-t]
 build/cli/nvm_addr      dev2gen dev_path 0xVAL [0xVAL...] [-h] [-v] [-t]
 build/cli/nvm_addr      lba2gen dev_path val [val...] [-h] [-v] [-t]
 build/cli/nvm_addr      off2gen dev_path val [val...] [-h] [-v] [-t]
 build/cli/nvm_addr      lpo2gen dev_path val [val...] [-h] [-v] [-t]

Options:
 -h       Print usage
 -v       Dump CLI state to stdout
 -t       Print only the address

See: http://lightnvm.io/liblightnvm/cli/ for usage examples
aravind@ocssd:~/OCSSD$
******************************************************************