### PR TITLE
fixes addr_dev type for test_cmd_rprt_ordr

### DIFF
--- a/tests/test_cmd_rprt_ordr.c
+++ b/tests/test_cmd_rprt_ordr.c
@@ -36,7 +36,7 @@ void test_CMD_RPRT_ORDR(void)
 		.l.pugrp = ((i / GEO->l.nchunk) / GEO->l.npunit) % GEO->l.npugrp
 		};
 
-		const uint32_t addr_dev = nvm_addr_gen2dev(DEV, addr);
+		const uint64_t addr_dev = nvm_addr_gen2dev(DEV, addr);
 
 		struct nvm_spec_rprt_descr *descr = &rprt->descr[i];
 


### PR DESCRIPTION
Instead of uint64_t, uint32_t was used for addr_dev, which got truncated and leads to failure cases even when chunk descriptor returns correct result. 