### PR TITLE
tests: fixed comparison of unsigned char and char for predefined data from unwritten blocks.

### DIFF
--- a/tests/util.c
+++ b/tests/util.c
@@ -85,7 +85,7 @@ void nvm_test_verify_read_ok_predef(int rc,
 	const char *NVM_UNUSED(expected), size_t count,
 	uint16_t NVM_UNUSED(err))
 {
-	unsigned char dlfeat_val;
+	char dlfeat_val;
 	size_t diff = 0;
 
 	switch (NS->dlfeat & 0x7) {


### PR DESCRIPTION
Problem hidden when dlfeat_val = 0x00, but exposed when
dlfeat_val = 0xff, where (const char)0xff != (unsigned char)0xff.