### PR TITLE
nvm_dev: rm redundant bbt_flush in dev_close

### DIFF
--- a/src/nvm_dev.c
+++ b/src/nvm_dev.c
@@ -463,7 +463,6 @@ void nvm_dev_close(struct nvm_dev *dev)
 
 	dev->be->close(dev);
 
-	nvm_bbt_flush_all(dev, NULL);
 	free(dev->bbts);
 	free(dev);
 }


### PR DESCRIPTION
Another nvm_bbt_flush_all is placed behind close(dev).
Didn't find any reasonable effect on it.