### PR TITLE
Fixing bad alignment invoking undefined behaviour

### DIFF
--- a/src/nvm_buf.c
+++ b/src/nvm_buf.c
@@ -87,7 +87,7 @@ void nvm_buf_virt_free(void *buf)
 
 void *nvm_buf_alloc(const struct nvm_dev *dev, size_t nbytes, uint64_t *phys)
 {
-	size_t alignment = 0;
+	size_t alignment = 4096;
 
 	switch(dev->geo.verid) {
 	case NVM_SPEC_VERID_12:
@@ -125,7 +125,7 @@ void *nvm_buf_alloc(const struct nvm_dev *dev, size_t nbytes, uint64_t *phys)
 void *nvm_buf_realloc(const struct nvm_dev *dev, void *buf, size_t nbytes,
 		      uint64_t *phys)
 {
-	size_t alignment = 0;
+	size_t alignment = 4096;
 
 	switch (dev->geo.verid) {
 	case NVM_SPEC_VERID_12:


### PR DESCRIPTION
During initialisation of the _ioctl_ backend, the `nvm_dev` struct is not fully populated with all applicable values. The absence of `verid` causes none of the switch clauses to be invoked, leading to `nvm_buf_virt_alloc`, and later _malloc_ being called with zero-byte alignment. Calling _malloc_ with zero-byte alignment is undefined-behaviour and causes the ioctl driver to not be initialised in some instances.

This pull request sets the alignment to 1 as a default, such that the undefined behaviour is not triggered.