### PR TITLE
doc: example compilation needs libaio with the SPDK backend

### DIFF
--- a/doc/src/backends/nvm_be_spdk.rst
+++ b/doc/src/backends/nvm_be_spdk.rst
@@ -132,7 +132,8 @@ Invoke like so::
     -lrt \
     -ldl \
     -lnuma \
-    -luuid
+    -luuid \
+    -laio
 
 The above compiles the example from the quick-start guide, note that the code
 has a hardcoded device identifier, you must change this to match the **SPDK**


### PR DESCRIPTION
In absence of `libaio`, the compilation fails: 
```bash
/usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/9/../../../../lib/liblightnvm.a(nvm_be_lbd.c.o): in function `nvm_be_lbd_async_init':
nvm_be_lbd.c:(.text+0xb8): undefined reference to `io_queue_init'
/usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/9/../../../../lib/liblightnvm.a(nvm_be_lbd.c.o): in function `nvm_be_lbd_async_term':
nvm_be_lbd.c:(.text+0x141): undefined reference to `io_queue_release'
/usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/9/../../../../lib/liblightnvm.a(nvm_be_lbd.c.o): in function `cmd_async_getevents':
nvm_be_lbd.c:(.text+0x2b7): undefined reference to `io_getevents'
/usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/9/../../../../lib/liblightnvm.a(nvm_be_lbd.c.o): in function `cmd_async_scalar_wr':
nvm_be_lbd.c:(.text+0x443): undefined reference to `io_submit'
collect2: error: ld returned 1 exit status
```
Signed-off-by: Animesh Trivedi <atrivedi@apache.org>